### PR TITLE
Support skipping of grouped tabs

### DIFF
--- a/lib/autoclose.js
+++ b/lib/autoclose.js
@@ -38,7 +38,17 @@ function tabsToClose (now, settings, tabs) {
 
     // closeable tabs (now or in the future), sorted from longest to shortest inactivity
     const closeableTabs =
-      unpinnedTabs.filter(tab => tab.audible === false && tab.lastAccessed < Infinity)
+      unpinnedTabs.filter(tab => {
+        // Filter out audible tabs and tabs with no lastAccessed timestamp
+        if (tab.audible === true || tab.lastAccessed >= Infinity) {
+          return false
+        }
+        // Filter out grouped tabs if the setting is enabled
+        if (settings.excludeTabsInGroups && tab.groupId != null && tab.groupId !== -1) {
+          return false
+        }
+        return true
+      })
       .sort((t1, t2) => t1.lastAccessed > t2.lastAccessed)
 
     const nowCloseableTabs =

--- a/lib/state.js
+++ b/lib/state.js
@@ -7,13 +7,15 @@
  * @property {integer} minTabsCount
  * @property {integer} maxHistorySize
  * @property {boolean} clearHistoryOnExit
+ * @property {boolean} excludeTabsInGroups
  */
 
 const defaultSettings = {
   minInactiveMilliseconds: 20 * 60 * 1000,
   minTabsCount: 5,
   maxHistorySize: 1000,
-  clearHistoryOnExit: true
+  clearHistoryOnExit: true,
+  excludeTabsInGroups: false
 }
 
 /**
@@ -66,6 +68,10 @@ function loadState () {
 
     if (settings.clearHistoryOnExit == null) {
       settings.clearHistoryOnExit = defaultSettings.clearHistoryOnExit
+    }
+
+    if (settings.excludeTabsInGroups == null) {
+      settings.excludeTabsInGroups = defaultSettings.excludeTabsInGroups
     }
     return state
   })

--- a/settings/de_DE/settings.html
+++ b/settings/de_DE/settings.html
@@ -49,6 +49,16 @@
         </label>
         <input type="checkbox" id="clear-history-on-exit" >
       </div>
+
+      <div class="form-group">
+        <label for="exclude-tabs-in-groups">
+          Tabs in Gruppen nicht automatisch schließen
+        </label>
+        <input type="checkbox" id="exclude-tabs-in-groups" aria-describedby="exclude-tabs-in-groups-descr" >
+        <p id="exclude-tabs-in-groups-descr">
+          Wenn aktiviert, werden Tabs, die zu einer Tab-Gruppe gehören, nicht automatisch geschlossen.
+        </p>
+      </div>
     </form>
     <script src="../../lib/state.js"></script>
     <script src="../settings.js"></script>

--- a/settings/en_US/settings.html
+++ b/settings/en_US/settings.html
@@ -49,6 +49,16 @@
         </label>
         <input type="checkbox" id="clear-history-on-exit" >
       </div>
+
+      <div class="form-group">
+        <label for="exclude-tabs-in-groups">
+          Don't auto-close tabs in groups
+        </label>
+        <input type="checkbox" id="exclude-tabs-in-groups" aria-describedby="exclude-tabs-in-groups-descr" >
+        <p id="exclude-tabs-in-groups-descr">
+          When enabled, tabs that belong to a tab group will not be automatically closed.
+        </p>
+      </div>
     </form>
     <script src="../../lib/state.js"></script>
     <script src="../settings.js"></script>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -54,11 +54,21 @@ function initializeClearHistoryOnExit (settings) {
   })
 }
 
+function initializeExcludeTabsInGroups (settings) {
+  const input = document.getElementById('exclude-tabs-in-groups')
+  input.checked = settings.excludeTabsInGroups
+  input.addEventListener('change', () => {
+    settings.excludeTabsInGroups = input.checked
+    persistSettings(settings)
+  })
+}
+
 function initializeSettingsUi (settings) {
   initializeMinInactiveMinutes(settings)
   initializeMinTabsCount(settings)
   initializeMaxHistorySize(settings)
   initializeClearHistoryOnExit(settings)
+  initializeExcludeTabsInGroups(settings)
 }
 
 loadState().then(state => initializeSettingsUi(state.settings))

--- a/settings/zh_CN/settings.html
+++ b/settings/zh_CN/settings.html
@@ -49,6 +49,16 @@
         </label>
         <input type="checkbox" id="clear-history-on-exit" >
       </div>
+
+      <div class="form-group">
+        <label for="exclude-tabs-in-groups">
+          不要自动关闭分组中的标签页
+        </label>
+        <input type="checkbox" id="exclude-tabs-in-groups" aria-describedby="exclude-tabs-in-groups-descr" >
+        <p id="exclude-tabs-in-groups-descr">
+          启用时，属于标签页分组的标签页不会被自动关闭。
+        </p>
+      </div>
     </form>
     <script src="../../lib/state.js"></script>
     <script src="../settings.js"></script>


### PR DESCRIPTION
A feature to exclude tabs that are part of a tab group from being auto-closed.